### PR TITLE
fix(base): Path.glob return nil when finished

### DIFF
--- a/lua/pathlib/base.lua
+++ b/lua/pathlib/base.lua
@@ -629,7 +629,9 @@ function Path:glob(pattern)
   local result, i = vim.fn.globpath(str, pattern, false, true), 0 ---@diagnostic disable-line
   return function()
     i = i + 1
-    return self.new(result[i])
+    if i <= #result then
+      return self.new(result[i])
+    end
   end
 end
 


### PR DESCRIPTION
Refer to https://www.lua.org/pil/7.1.html
> When there are no more values in the list, the iterator returns nil. 