### PR TITLE
fix(base): `Path:tostring` `sep` argument is not longer ignored

### DIFF
--- a/lua/pathlib/base.lua
+++ b/lua/pathlib/base.lua
@@ -1186,10 +1186,11 @@ end
 function Path:tostring(sep)
   local nocache = sep and sep ~= self.sep_str
   if nocache or not self.__string_cache then
-    local s = table.concat(self._raw_paths, self.sep_str)
+    sep = sep or self.sep_str
+    local s = table.concat(self._raw_paths, sep)
     if self:is_absolute() then
       if #self._raw_paths == 1 then
-        s = self.sep_str
+        s = sep
       end
       if self._drive_name:len() > 0 then
         s = self._drive_name .. s


### PR DESCRIPTION
Hi ! Thanks a lot for the lib, I use it very often for small, custom plugins. It saves a lot of painful work !

I recently tried to use it to format Python module paths (like `package.module`) using `Path:tostring` `sep` argument, to return a dot separated path.

But if you run the following:

```lua
Path("package/module.py"):with_suffix(""):tostring(".")
```

you will get `package/module`, not `package.module`.

I looked into the code and it looks like the `sep` argument is not actually used to format the returned string (`self.sep_str` is used instead). It's only used check if the stored cache is usable.

I was about to create an issue but figured it would be quick to fix.

This is the modification I use locally, but if you have another fix in mind don't hesitate to close the PR. I don't know the code base so there may be other considerations I didn't take into account.

Thanks a lot and have a nice day !